### PR TITLE
Add coverlet.msbuild and sonarscan script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/.sonarqube/conf

--- a/Penguin/Directory.Packages.props
+++ b/Penguin/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageVersion Include="Azure.Identity" Version="1.13.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+	<PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />

--- a/Penguin/tests/Application.FunctionalTests/Application.FunctionalTests.csproj
+++ b/Penguin/tests/Application.FunctionalTests/Application.FunctionalTests.csproj
@@ -1,43 +1,47 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <RootNamespace>Penguin.Application.FunctionalTests</RootNamespace>
-        <AssemblyName>Penguin.Application.FunctionalTests</AssemblyName>
-    </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>Penguin.Application.FunctionalTests</RootNamespace>
+    <AssemblyName>Penguin.Application.FunctionalTests</AssemblyName>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <None Remove="appsettings.json" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <Content Include="appsettings.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </Content>
-    </ItemGroup>
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="nunit" />
-        <PackageReference Include="NUnit.Analyzers">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="coverlet.collector">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" />
-        <PackageReference Include="Moq" />
-        <PackageReference Include="Respawn" />
-        <PackageReference Include="Testcontainers.MsSql" />
-    </ItemGroup>
-    
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Web\Web.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="nunit" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Respawn" />
+    <PackageReference Include="Testcontainers.MsSql" />
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Web\Web.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Penguin/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/Penguin/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -19,6 +19,10 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Moq" />
+      <PackageReference Include="coverlet.msbuild">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Penguin/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/Penguin/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -18,6 +18,10 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" />
+      <PackageReference Include="coverlet.msbuild">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Penguin/tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj
+++ b/Penguin/tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj
@@ -1,22 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <RootNamespace>Penguin.Infrastructure.IntegrationTests</RootNamespace>
-        <AssemblyName>Penguin.Infrastructure.IntegrationTests</AssemblyName>
-    </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>Penguin.Infrastructure.IntegrationTests</RootNamespace>
+    <AssemblyName>Penguin.Infrastructure.IntegrationTests</AssemblyName>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="NUnit" />
-        <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="NUnit.Analyzers">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/sonarscan.bat
+++ b/sonarscan.bat
@@ -1,0 +1,16 @@
+@echo off
+set mainSolution=Penguin.sln
+set sonarQubeProjectKey=Penguin
+set token=%1
+set buildTag=main
+
+if NOT "%~2"=="" (
+	set buildTag=%2
+)
+
+set sonarParameters=/v:%buildTag% /key:%sonarQubeProjectKey% /d:sonar.login=%token% /d:sonar.cs.opencover.reportsPaths=**/TestResults/coverage.opencover.xml /d:sonar.host.url=http://192.168.1.103:9001/
+
+dotnet sonarscanner begin %sonarParameters%
+dotnet build
+dotnet test /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover --no-build
+dotnet sonarscanner end /d:sonar.login=%token%


### PR DESCRIPTION
Updated Directory.Packages.props to include coverlet.msbuild version 6.0.2. Reformatted and added coverlet.msbuild to Application.FunctionalTests.csproj and Infrastructure.IntegrationTests.csproj. Updated Application.UnitTests.csproj and Domain.UnitTests.csproj to include coverlet.msbuild with appropriate settings. Added sonarscan.bat script for SonarQube analysis.

Add coverlet.msbuild and create SonarQube script

Added the `coverlet.msbuild` package to `Directory.Packages.props` and included it in `Application.FunctionalTests.csproj`, `Application.UnitTests.csproj`, `Domain.UnitTests.csproj`, and `Infrastructure.IntegrationTests.csproj`. Reformatted `Application.FunctionalTests.csproj` and `Infrastructure.IntegrationTests.csproj` for better readability. Created `sonarscan.bat` to automate SonarQube analysis.